### PR TITLE
call HostFrame with real time duration

### DIFF
--- a/source/quakegeneric.c
+++ b/source/quakegeneric.c
@@ -20,9 +20,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "quakedef.h"
 
-void QG_Tick(void)
+void QG_Tick(double duration)
 {
-	Host_Frame(0.1);
+	Host_Frame(duration);
 }
 
 void QG_Create(int argc, char *argv[])

--- a/source/quakegeneric.h
+++ b/source/quakegeneric.h
@@ -24,7 +24,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define QUAKEGENERIC_RES_Y 200
 
 // provided functions
-void QG_Tick(void);
+void QG_Tick(double duration);
 void QG_Create(int argc, char *argv[]);
 
 // user must implement these

--- a/source/quakegeneric_sdl2.c
+++ b/source/quakegeneric_sdl2.c
@@ -223,10 +223,12 @@ void QG_DrawFrame(void *pixels, void *palette)
 
 int main(int argc, char *argv[])
 {
+	double oldtime, newtime;
 	int running = 1;
 
 	QG_Create(argc, argv);
 
+	oldtime = (double)SDL_GetPerformanceCounter() / SDL_GetPerformanceFrequency() - 0.1;
 	while (running)
 	{
 		// poll events
@@ -245,7 +247,10 @@ int main(int argc, char *argv[])
 			}
 		}
 
-		QG_Tick();
+		// Run the frame at the correct duration.
+		newtime = (double)SDL_GetPerformanceCounter() / SDL_GetPerformanceFrequency();
+		QG_Tick(newtime - oldtime);
+		oldtime = newtime;
 	}
 
 	return 0;


### PR DESCRIPTION
The game runs in real time now, but still churns 100% CPU.  To implement sleeping between frames I think we'd have to dig into the Quake time filtering logic a bit, which is perhaps more than we want to do?