### PR TITLE
Add support for mouse and mouse buttons

### DIFF
--- a/source/in_null.c
+++ b/source/in_null.c
@@ -23,6 +23,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "quakegeneric.h"
 
+float	mouse_x, mouse_y;
+
 void IN_Init (void)
 {
 }
@@ -41,8 +43,47 @@ void IN_Commands (void)
 	}
 }
 
+void IN_MouseMove (usercmd_t *cmd)
+{
+	int		mx, my;
+
+	QG_GetMouseMove(&mx, &my);
+
+	mouse_x = mx;
+	mouse_y = my;
+
+	mouse_x *= sensitivity.value;
+	mouse_y *= sensitivity.value;
+
+	// add mouse X/Y movement to cmd
+	if ( (in_strafe.state & 1) || (lookstrafe.value && (in_mlook.state & 1) ))
+		cmd->sidemove += m_side.value * mouse_x;
+	else
+		cl.viewangles[YAW] -= m_yaw.value * mouse_x;
+
+	if (in_mlook.state & 1)
+		V_StopPitchDrift ();
+
+	if ( (in_mlook.state & 1) && !(in_strafe.state & 1))
+	{
+		cl.viewangles[PITCH] += m_pitch.value * mouse_y;
+		if (cl.viewangles[PITCH] > 80)
+			cl.viewangles[PITCH] = 80;
+		if (cl.viewangles[PITCH] < -70)
+			cl.viewangles[PITCH] = -70;
+	}
+	else
+	{
+		if ((in_strafe.state & 1) && noclip_anglehack)
+			cmd->upmove -= m_forward.value * mouse_y;
+		else
+			cmd->forwardmove -= m_forward.value * mouse_y;
+	}
+}
+
 void IN_Move (usercmd_t *cmd)
 {
-	// TODO: Modify `cmd` with things like mouse / joystick input.
+	IN_MouseMove (cmd);
+	// TODO: Joystick input
 }
 

--- a/source/quakegeneric.h
+++ b/source/quakegeneric.h
@@ -35,5 +35,6 @@ void QG_Init(void);
 void QG_Quit(void);
 void QG_DrawFrame(void *pixels, void *palette);
 int QG_GetKey(int *down, int *key);
+void QG_GetMouseMove(int *x, int *y);
 
 #endif // __QUAKEGENERIC__

--- a/source/quakegeneric_sdl2.c
+++ b/source/quakegeneric_sdl2.c
@@ -37,6 +37,7 @@ static int keybuffer[KEYBUFFERSIZE];  // circular key buffer
 static int keybuffer_len;  // number of keys in the buffer
 static int keybuffer_start;  // index of next item to be read
 
+static int mouse_x, mouse_y;
 
 void QG_Init(void)
 {
@@ -45,6 +46,12 @@ void QG_Init(void)
 	renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_SOFTWARE | SDL_RENDERER_PRESENTVSYNC);
 	texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, QUAKEGENERIC_RES_X, QUAKEGENERIC_RES_Y);
 	rgbpixels = malloc(QUAKEGENERIC_RES_X * QUAKEGENERIC_RES_Y * sizeof(uint32_t));
+
+	SDL_SetRelativeMouseMode(SDL_TRUE);
+
+	keybuffer_len = 0;
+	keybuffer_start = 0;
+	mouse_x = mouse_y = 0;
 }
 
 static int ConvertToQuakeKey(unsigned int key)
@@ -196,6 +203,14 @@ int QG_GetKey(int *down, int *key)
 	return KeyPop(down, key);
 }
 
+void QG_GetMouseMove(int *x, int *y)
+{
+	*x = mouse_x;
+	*y = mouse_y;
+
+	mouse_x = mouse_y = 0;
+}
+
 void QG_Quit(void)
 {
 	if (window) SDL_DestroyWindow(window);
@@ -293,6 +308,10 @@ int main(int argc, char *argv[])
 				case SDL_KEYDOWN:
 				case SDL_KEYUP:
 					(void) KeyPush((event.type == SDL_KEYDOWN), ConvertToQuakeKey(event.key.keysym.sym));
+					break;
+				case SDL_MOUSEMOTION:
+					mouse_x += event.motion.xrel;
+					mouse_y += event.motion.yrel;
 					break;
 			}
 		}

--- a/source/quakegeneric_sdl2.c
+++ b/source/quakegeneric_sdl2.c
@@ -39,6 +39,7 @@ static int keybuffer_start;  // index of next item to be read
 
 static int mouse_x, mouse_y;
 
+
 void QG_Init(void)
 {
 	SDL_Init(SDL_INIT_EVERYTHING);
@@ -52,6 +53,28 @@ void QG_Init(void)
 	keybuffer_len = 0;
 	keybuffer_start = 0;
 	mouse_x = mouse_y = 0;
+}
+
+static int ConvertToQuakeButton(unsigned char button)
+{
+	int qbutton;
+
+	switch (button)
+	{
+		case 1:
+			qbutton = K_MOUSE1;
+			break;
+		case 2:
+			qbutton = K_MOUSE3;
+			break;
+		case 3:
+			qbutton = K_MOUSE2;
+			break;
+		default:
+			qbutton = -1;
+			break;
+	}
+	return qbutton;
 }
 
 static int ConvertToQuakeKey(unsigned int key)
@@ -162,11 +185,8 @@ static int ConvertToQuakeKey(unsigned int key)
 
 		/*
 		 * Not yet converted:
-		 *   K_MOUSE*
 		 *   K_JOY*
 		 *   K_AUX*
-		 *   K_MWHEELUP
-		 *   K_MWHEELDOWN
 		 */
 	}
 
@@ -290,6 +310,7 @@ int main(int argc, char *argv[])
 {
 	double oldtime, newtime;
 	int running = 1;
+	int button;
 
 	QG_Create(argc, argv);
 
@@ -312,6 +333,25 @@ int main(int argc, char *argv[])
 				case SDL_MOUSEMOTION:
 					mouse_x += event.motion.xrel;
 					mouse_y += event.motion.yrel;
+					break;
+				case SDL_MOUSEBUTTONDOWN:
+				case SDL_MOUSEBUTTONUP:
+					button = ConvertToQuakeButton(event.button.button);
+					if (button != -1) {
+						(void) KeyPush((event.type == SDL_MOUSEBUTTONDOWN), button);
+					}
+					break;
+				case SDL_MOUSEWHEEL:
+					if (event.wheel.y > 0)
+					{
+						(void) KeyPush(1, K_MWHEELUP);
+						(void) KeyPush(0, K_MWHEELUP);
+					}
+					else if (event.wheel.y < 0)
+					{
+						(void) KeyPush(1, K_MWHEELDOWN);
+						(void) KeyPush(0, K_MWHEELDOWN);
+					}
 					break;
 			}
 		}


### PR DESCRIPTION
Users must implement `QG_GetMouseMove` to fetch relative mouse movements.  Mouse button presses and wheel motions are fetched via `QG_GetKey`, the same as keyboard presses.