### PR TITLE
64-bit support

### DIFF
--- a/source/common.c
+++ b/source/common.c
@@ -139,7 +139,7 @@ void Q_memset (void *dest, int fill, int count)
 {
 	int             i;
 	
-	if ( (((long)dest | count) & 3) == 0)
+	if ( (((intptr_t)dest | count) & 3) == 0)
 	{
 		count >>= 2;
 		fill = fill | (fill<<8) | (fill<<16) | (fill<<24);
@@ -155,7 +155,7 @@ void Q_memcpy (void *dest, void *src, int count)
 {
 	int             i;
 	
-	if (( ( (long)dest | (long)src | count) & 3) == 0 )
+	if (( ( (intptr_t)dest | (intptr_t)src | count) & 3) == 0 )
 	{
 		count>>=2;
 		for (i=0 ; i<count ; i++)

--- a/source/common.h
+++ b/source/common.h
@@ -63,7 +63,7 @@ void InsertLinkAfter (link_t *l, link_t *after);
 // (type *)STRUCT_FROM_LINK(link_t *link, type, member)
 // ent = STRUCT_FROM_LINK(link,entity_t,order)
 // FIXME: remove this mess!
-#define	STRUCT_FROM_LINK(l,t,m) ((t *)((byte *)l - (int)&(((t *)0)->m)))
+#define	STRUCT_FROM_LINK(l,t,m) ((t *)((byte *)l - (intptr_t)&(((t *)0)->m)))
 
 //============================================================================
 

--- a/source/console.c
+++ b/source/console.c
@@ -22,7 +22,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #ifdef NeXT
 #include <libc.h>
 #endif
-#ifndef _MSC_VER
+#ifdef _MSC_VER
+#include <io.h> // open, write, close
+#else
 #include <unistd.h>
 #endif
 #include <fcntl.h>

--- a/source/d_edge.c
+++ b/source/d_edge.c
@@ -195,7 +195,7 @@ void D_DrawSurfaces (void)
 			d_zistepv = s->d_zistepv;
 			d_ziorigin = s->d_ziorigin;
 
-			D_DrawSolidSurface (s, (int)s->data & 0xFF);
+			D_DrawSolidSurface (s, (intptr_t)s->data & 0xFF);
 			D_DrawZSpans (s->spans);
 		}
 	}

--- a/source/d_fill.c
+++ b/source/d_fill.c
@@ -58,7 +58,7 @@ void D_FillRect (vrect_t *rect, int color)
 
 	dest = ((byte *)vid.buffer + ry*vid.rowbytes + rx);
 
-	if (((rwidth & 0x03) == 0) && (((long)dest & 0x03) == 0))
+	if (((rwidth & 0x03) == 0) && (((intptr_t)dest & 0x03) == 0))
 	{
 	// faster aligned dword clear
 		ldest = (unsigned *)dest;

--- a/source/d_polyse.c
+++ b/source/d_polyse.c
@@ -127,7 +127,7 @@ void D_PolysetDraw (void)
 						// one extra because of cache line pretouching
 
 	a_spans = (spanpackage_t *)
-			(((long)&spans[0] + CACHE_SIZE - 1) & ~(CACHE_SIZE - 1));
+			(((intptr_t)&spans[0] + CACHE_SIZE - 1) & ~(CACHE_SIZE - 1));
 
 	if (r_affinetridesc.drawtype)
 	{

--- a/source/d_scan.c
+++ b/source/d_scan.c
@@ -405,7 +405,7 @@ void D_DrawZSpans (espan_t *pspan)
 	// we count on FP exceptions being turned off to avoid range problems
 		izi = (int)(zi * 0x8000 * 0x10000);
 
-		if ((long)pdest & 0x02)
+		if ((intptr_t)pdest & 0x02)
 		{
 			*pdest++ = (short)(izi >> 16);
 			izi += izistep;

--- a/source/makefile
+++ b/source/makefile
@@ -20,8 +20,8 @@ override CFLAGS += -O3
 override LDFLAGS += -O3
 endif
 
-override CFLAGS += -m32 -std=gnu99 $(shell sdl2-config --cflags)
-override LDFLAGS += -lm -m32 $(shell sdl2-config --libs)
+override CFLAGS += -std=gnu99 $(shell sdl2-config --cflags)
+override LDFLAGS += -lm $(shell sdl2-config --libs)
 
 OBJECTS = \
 	cd_null.o \

--- a/source/net_main.c
+++ b/source/net_main.c
@@ -449,9 +449,9 @@ NET_CheckNewConnections
 
 struct
 {
-	double	time;
-	int		op;
-	long	session;
+	double		time;
+	int			op;
+	intptr_t	session;
 } vcrConnect;
 
 qsocket_t *NET_CheckNewConnections (void)
@@ -473,7 +473,7 @@ qsocket_t *NET_CheckNewConnections (void)
 			{
 				vcrConnect.time = host_time;
 				vcrConnect.op = VCR_OP_CONNECT;
-				vcrConnect.session = (long)ret;
+				vcrConnect.session = (intptr_t)ret;
 				Sys_FileWrite (vcrFile, &vcrConnect, sizeof(vcrConnect));
 				Sys_FileWrite (vcrFile, ret->address, NET_NAMELEN);
 			}
@@ -528,11 +528,11 @@ returns -1 if connection is invalid
 
 struct
 {
-	double	time;
-	int		op;
-	long	session;
-	int		ret;
-	int		len;
+	double		time;
+	int			op;
+	intptr_t	session;
+	int			ret;
+	int			len;
 } vcrGetMessage;
 
 extern void PrintStats(qsocket_t *s);
@@ -580,7 +580,7 @@ int	NET_GetMessage (qsocket_t *sock)
 		{
 			vcrGetMessage.time = host_time;
 			vcrGetMessage.op = VCR_OP_GETMESSAGE;
-			vcrGetMessage.session = (long)sock;
+			vcrGetMessage.session = (intptr_t)sock;
 			vcrGetMessage.ret = ret;
 			vcrGetMessage.len = net_message.cursize;
 			Sys_FileWrite (vcrFile, &vcrGetMessage, 24);
@@ -593,7 +593,7 @@ int	NET_GetMessage (qsocket_t *sock)
 		{
 			vcrGetMessage.time = host_time;
 			vcrGetMessage.op = VCR_OP_GETMESSAGE;
-			vcrGetMessage.session = (long)sock;
+			vcrGetMessage.session = (intptr_t)sock;
 			vcrGetMessage.ret = ret;
 			Sys_FileWrite (vcrFile, &vcrGetMessage, 20);
 		}
@@ -616,10 +616,10 @@ returns -1 if the connection died
 */
 struct
 {
-	double	time;
-	int		op;
-	long	session;
-	int		r;
+	double		time;
+	int			op;
+	intptr_t	session;
+	int			r;
 } vcrSendMessage;
 
 int NET_SendMessage (qsocket_t *sock, sizebuf_t *data)
@@ -644,7 +644,7 @@ int NET_SendMessage (qsocket_t *sock, sizebuf_t *data)
 	{
 		vcrSendMessage.time = host_time;
 		vcrSendMessage.op = VCR_OP_SENDMESSAGE;
-		vcrSendMessage.session = (long)sock;
+		vcrSendMessage.session = (intptr_t)sock;
 		vcrSendMessage.r = r;
 		Sys_FileWrite (vcrFile, &vcrSendMessage, 20);
 	}
@@ -675,7 +675,7 @@ int NET_SendUnreliableMessage (qsocket_t *sock, sizebuf_t *data)
 	{
 		vcrSendMessage.time = host_time;
 		vcrSendMessage.op = VCR_OP_SENDMESSAGE;
-		vcrSendMessage.session = (long)sock;
+		vcrSendMessage.session = (intptr_t)sock;
 		vcrSendMessage.r = r;
 		Sys_FileWrite (vcrFile, &vcrSendMessage, 20);
 	}
@@ -710,7 +710,7 @@ qboolean NET_CanSendMessage (qsocket_t *sock)
 	{
 		vcrSendMessage.time = host_time;
 		vcrSendMessage.op = VCR_OP_CANSENDMESSAGE;
-		vcrSendMessage.session = (long)sock;
+		vcrSendMessage.session = (intptr_t)sock;
 		vcrSendMessage.r = r;
 		Sys_FileWrite (vcrFile, &vcrSendMessage, 20);
 	}

--- a/source/net_vcr.c
+++ b/source/net_vcr.c
@@ -31,9 +31,9 @@ extern int vcrFile;
 
 static struct
 {
-	double	time;
-	int		op;
-	long	session;
+	double		time;
+	int			op;
+	intptr_t	session;
 }	next;
 
 int VCR_Init (void)
@@ -79,7 +79,7 @@ int VCR_GetMessage (qsocket_t *sock)
 {
 	int	ret;
 	
-	if (host_time != next.time || next.op != VCR_OP_GETMESSAGE || next.session != *(long *)(&sock->driverdata))
+	if (host_time != next.time || next.op != VCR_OP_GETMESSAGE || next.session != *(intptr_t *)(&sock->driverdata))
 		Sys_Error ("VCR missmatch");
 
 	Sys_FileRead(vcrFile, &ret, sizeof(int));
@@ -102,7 +102,7 @@ int VCR_SendMessage (qsocket_t *sock, sizebuf_t *data)
 {
 	int	ret;
 
-	if (host_time != next.time || next.op != VCR_OP_SENDMESSAGE || next.session != *(long *)(&sock->driverdata))
+	if (host_time != next.time || next.op != VCR_OP_SENDMESSAGE || next.session != *(intptr_t *)(&sock->driverdata))
 		Sys_Error ("VCR missmatch");
 
 	Sys_FileRead(vcrFile, &ret, sizeof(int));
@@ -117,7 +117,7 @@ qboolean VCR_CanSendMessage (qsocket_t *sock)
 {
 	qboolean	ret;
 
-	if (host_time != next.time || next.op != VCR_OP_CANSENDMESSAGE || next.session != *(long *)(&sock->driverdata))
+	if (host_time != next.time || next.op != VCR_OP_CANSENDMESSAGE || next.session != *(intptr_t *)(&sock->driverdata))
 		Sys_Error ("VCR missmatch");
 
 	Sys_FileRead(vcrFile, &ret, sizeof(int));
@@ -158,7 +158,7 @@ qsocket_t *VCR_CheckNewConnections (void)
 	}
 
 	sock = NET_NewQSocket ();
-	*(long *)(&sock->driverdata) = next.session;
+	*(intptr_t *)(&sock->driverdata) = next.session;
 
 	Sys_FileRead (vcrFile, sock->address, NET_NAMELEN);
 	VCR_ReadNext ();

--- a/source/quakedef.h
+++ b/source/quakedef.h
@@ -34,6 +34,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include <stdlib.h>
 #include <setjmp.h>
 
+#include <stddef.h>				// Slart: For intptr_t, unlikely to be supported on all compilers
+
 #define	VID_LockBuffer()
 #define	VID_UnlockBuffer()
 

--- a/source/quakedef.h
+++ b/source/quakedef.h
@@ -34,7 +34,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include <stdlib.h>
 #include <setjmp.h>
 
-#include <stddef.h>				// Slart: For intptr_t, unlikely to be supported on all compilers
+// Slart: For intptr_t, unlikely to be supported on all compilers
+#include <stddef.h>
+#include <stdint.h>
 
 #define	VID_LockBuffer()
 #define	VID_UnlockBuffer()

--- a/source/r_alias.c
+++ b/source/r_alias.c
@@ -704,7 +704,7 @@ void R_AliasDrawModel (alight_t *plighting)
 
 // cache align
 	pfinalverts = (finalvert_t *)
-			(((long)&finalverts[0] + CACHE_SIZE - 1) & ~(CACHE_SIZE - 1));
+			(((intptr_t)&finalverts[0] + CACHE_SIZE - 1) & ~(CACHE_SIZE - 1));
 	pauxverts = &auxverts[0];
 
 	paliashdr = (aliashdr_t *)Mod_Extradata (currententity->model);

--- a/source/r_draw.c
+++ b/source/r_draw.c
@@ -358,7 +358,7 @@ void R_EmitCachedEdge (void)
 {
 	edge_t		*pedge_t;
 
-	pedge_t = (edge_t *)((unsigned long)r_edges + r_pedge->cachededgeoffset);
+	pedge_t = (edge_t *)((uintptr_t)r_edges + r_pedge->cachededgeoffset);
 
 	if (!pedge_t->surfs[0])
 		pedge_t->surfs[0] = surface_p - surfaces;
@@ -445,9 +445,9 @@ void R_RenderFace (msurface_t *fa, int clipflags)
 				}
 				else
 				{
-					if ((((unsigned long)edge_p - (unsigned long)r_edges) >
+					if ((((uintptr_t)edge_p - (uintptr_t)r_edges) >
 						 r_pedge->cachededgeoffset) &&
-						(((edge_t *)((unsigned long)r_edges +
+						(((edge_t *)((uintptr_t)r_edges +
 						 r_pedge->cachededgeoffset))->owner == r_pedge))
 					{
 						R_EmitCachedEdge ();
@@ -491,9 +491,9 @@ void R_RenderFace (msurface_t *fa, int clipflags)
 				{
 				// it's cached if the cached edge is valid and is owned
 				// by this medge_t
-					if ((((unsigned long)edge_p - (unsigned long)r_edges) >
+					if ((((uintptr_t)edge_p - (uintptr_t)r_edges) >
 						 r_pedge->cachededgeoffset) &&
-						(((edge_t *)((unsigned long)r_edges +
+						(((edge_t *)((uintptr_t)r_edges +
 						 r_pedge->cachededgeoffset))->owner == r_pedge))
 					{
 						R_EmitCachedEdge ();

--- a/source/r_edge.c
+++ b/source/r_edge.c
@@ -646,7 +646,7 @@ void R_ScanEdges (void)
 	surf_t	*s;
 
 	basespan_p = (espan_t *)
-			((long)(basespans + CACHE_SIZE - 1) & ~(CACHE_SIZE - 1));
+			((intptr_t)(basespans + CACHE_SIZE - 1) & ~(CACHE_SIZE - 1));
 	max_span_p = &basespan_p[MAXSPANS - r_refdef.vrect.width];
 
 	span_p = basespan_p;

--- a/source/r_main.c
+++ b/source/r_main.c
@@ -859,13 +859,13 @@ void R_EdgeDrawing (void)
 	else
 	{
 		r_edges =  (edge_t *)
-				(((long)&ledges[0] + CACHE_SIZE - 1) & ~(CACHE_SIZE - 1));
+				(((intptr_t)&ledges[0] + CACHE_SIZE - 1) & ~(CACHE_SIZE - 1));
 	}
 
 	if (r_surfsonstack)
 	{
 		surfaces =  (surf_t *)
-				(((long)&lsurfs[0] + CACHE_SIZE - 1) & ~(CACHE_SIZE - 1));
+				(((intptr_t)&lsurfs[0] + CACHE_SIZE - 1) & ~(CACHE_SIZE - 1));
 		surf_max = &surfaces[r_cnumsurfs];
 	// surface 0 doesn't really exist; it's just a dummy because index 0
 	// is used to indicate no edge attached to surface
@@ -1030,10 +1030,10 @@ void R_RenderView (void)
 	if ( Hunk_LowMark() & 3 )
 		Sys_Error ("Hunk is missaligned");
 
-	if ( (long)(&dummy) & 3 )
+	if ( (intptr_t)(&dummy) & 3 )
 		Sys_Error ("Stack is missaligned");
 
-	if ( (long)(&r_warpbuffer) & 3 )
+	if ( (intptr_t)(&r_warpbuffer) & 3 )
 		Sys_Error ("Globals are missaligned");
 
 	R_RenderView_ ();

--- a/source/r_surf.c
+++ b/source/r_surf.c
@@ -556,7 +556,7 @@ void R_DrawSurfaceBlock16 (void)
 		pbasesource += sourcetstep;
 		lightright += lightrightstep;
 		lightleft += lightleftstep;
-		prowdest = (unsigned short *)((long)prowdest + surfrowbytes);
+		prowdest = (unsigned short *)((intptr_t)prowdest + surfrowbytes);
 	}
 
 	prowdestbase = prowdest;


### PR DESCRIPTION
Allows 64-bit support on Windows by replacing casts to long and int with intptr_t.
I haven't tested this outside of Windows MSVC, I imagine the DOS compilers wouldn't have intptr_t available, so a custom type might need to be created for that platform in common.h.