### PR TITLE
Add joystick support

### DIFF
--- a/source/in_null.c
+++ b/source/in_null.c
@@ -23,10 +23,61 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "quakegeneric.h"
 
+#define JOY_ABSOLUTE_AXIS	0x00000000		// control like a joystick
+#define JOY_RELATIVE_AXIS	0x00000010		// control like a mouse, spinner, trackball
+
+enum _ControlList
+{
+	AxisNada = 0, AxisForward, AxisLook, AxisSide, AxisTurn
+};
+
 float	mouse_x, mouse_y;
+cvar_t	in_joystick = {"joystick","0", true};
+cvar_t	joy_advanced = {"joyadvanced", "0"};
+cvar_t	joy_advaxisx = {"joyadvaxisx", "0"};
+cvar_t	joy_advaxisy = {"joyadvaxisy", "0"};
+cvar_t	joy_advaxisz = {"joyadvaxisz", "0"};
+cvar_t	joy_advaxisr = {"joyadvaxisr", "0"};
+cvar_t	joy_advaxisu = {"joyadvaxisu", "0"};
+cvar_t	joy_advaxisv = {"joyadvaxisv", "0"};
+cvar_t	joy_forwardthreshold = {"joyforwardthreshold", "0.15"};
+cvar_t	joy_sidethreshold = {"joysidethreshold", "0.15"};
+cvar_t	joy_pitchthreshold = {"joypitchthreshold", "0.15"};
+cvar_t	joy_yawthreshold = {"joyyawthreshold", "0.15"};
+cvar_t	joy_forwardsensitivity = {"joyforwardsensitivity", "-1.0"};
+cvar_t	joy_sidesensitivity = {"joysidesensitivity", "-1.0"};
+cvar_t	joy_pitchsensitivity = {"joypitchsensitivity", "1.0"};
+cvar_t	joy_yawsensitivity = {"joyyawsensitivity", "-1.0"};
+
+qboolean	joy_advancedinit;
+int dwAxisMap[QUAKEGENERIC_JOY_MAX_AXES];
+int dwControlMap[QUAKEGENERIC_JOY_MAX_AXES];
+
+void Joy_AdvancedUpdate_f (void);
+
 
 void IN_Init (void)
 {
+	Cvar_RegisterVariable (&in_joystick);
+	Cvar_RegisterVariable (&joy_advanced);
+	Cvar_RegisterVariable (&joy_advaxisx);
+	Cvar_RegisterVariable (&joy_advaxisy);
+	Cvar_RegisterVariable (&joy_advaxisz);
+	Cvar_RegisterVariable (&joy_advaxisr);
+	Cvar_RegisterVariable (&joy_advaxisu);
+	Cvar_RegisterVariable (&joy_advaxisv);
+	Cvar_RegisterVariable (&joy_forwardthreshold);
+	Cvar_RegisterVariable (&joy_sidethreshold);
+	Cvar_RegisterVariable (&joy_pitchthreshold);
+	Cvar_RegisterVariable (&joy_yawthreshold);
+	Cvar_RegisterVariable (&joy_forwardsensitivity);
+	Cvar_RegisterVariable (&joy_sidesensitivity);
+	Cvar_RegisterVariable (&joy_pitchsensitivity);
+	Cvar_RegisterVariable (&joy_yawsensitivity);
+
+	Cmd_AddCommand ("joyadvancedupdate", Joy_AdvancedUpdate_f);
+
+	joy_advancedinit = false;
 }
 
 void IN_Shutdown (void)
@@ -81,9 +132,202 @@ void IN_MouseMove (usercmd_t *cmd)
 	}
 }
 
+void Joy_AdvancedUpdate_f (void)
+{
+
+	// called once by IN_ReadJoystick and by user whenever an update is needed
+	// cvars are now available
+	int	i;
+	int dwTemp;
+
+	// initialize all the maps
+	for (i = 0; i < QUAKEGENERIC_JOY_MAX_AXES; i++)
+	{
+		dwAxisMap[i] = AxisNada;
+		dwControlMap[i] = JOY_ABSOLUTE_AXIS;
+	}
+
+	if( joy_advanced.value == 0.0)
+	{
+		// default joystick initialization
+		// 2 axes only with joystick control
+		dwAxisMap[QUAKEGENERIC_JOY_AXIS_X] = AxisTurn;
+		dwAxisMap[QUAKEGENERIC_JOY_AXIS_Y] = AxisForward;
+	}
+	else
+	{
+		// advanced initialization here
+		// data supplied by user via joy_axisn cvars
+		dwTemp = (int) joy_advaxisx.value;
+		dwAxisMap[QUAKEGENERIC_JOY_AXIS_X] = dwTemp & 0x0000000f;
+		dwControlMap[QUAKEGENERIC_JOY_AXIS_X] = dwTemp & JOY_RELATIVE_AXIS;
+		dwTemp = (int) joy_advaxisy.value;
+		dwAxisMap[QUAKEGENERIC_JOY_AXIS_Y] = dwTemp & 0x0000000f;
+		dwControlMap[QUAKEGENERIC_JOY_AXIS_Y] = dwTemp & JOY_RELATIVE_AXIS;
+		dwTemp = (int) joy_advaxisz.value;
+		dwAxisMap[QUAKEGENERIC_JOY_AXIS_Z] = dwTemp & 0x0000000f;
+		dwControlMap[QUAKEGENERIC_JOY_AXIS_Z] = dwTemp & JOY_RELATIVE_AXIS;
+		dwTemp = (int) joy_advaxisr.value;
+		dwAxisMap[QUAKEGENERIC_JOY_AXIS_R] = dwTemp & 0x0000000f;
+		dwControlMap[QUAKEGENERIC_JOY_AXIS_R] = dwTemp & JOY_RELATIVE_AXIS;
+		dwTemp = (int) joy_advaxisu.value;
+		dwAxisMap[QUAKEGENERIC_JOY_AXIS_U] = dwTemp & 0x0000000f;
+		dwControlMap[QUAKEGENERIC_JOY_AXIS_U] = dwTemp & JOY_RELATIVE_AXIS;
+		dwTemp = (int) joy_advaxisv.value;
+		dwAxisMap[QUAKEGENERIC_JOY_AXIS_V] = dwTemp & 0x0000000f;
+		dwControlMap[QUAKEGENERIC_JOY_AXIS_V] = dwTemp & JOY_RELATIVE_AXIS;
+	}
+}
+
+// Adapted from Quake's in_win.c, since in_dos.c only supports discrete joystick inputs.
+void IN_JoyMove (usercmd_t *cmd)
+{
+	float	axisValues[QUAKEGENERIC_JOY_MAX_AXES] = {0};
+	float	speed, aspeed;
+	float	fAxisValue, fTemp;
+	int		i;
+
+	if ( joy_advancedinit != true )
+	{
+		Joy_AdvancedUpdate_f();
+		joy_advancedinit = true;
+	}
+
+	if (!in_joystick.value)
+		return;
+
+	// collect the joystick data, if possible
+	QG_GetJoyAxes(axisValues);
+
+	if (in_speed.state & 1)
+		speed = cl_movespeedkey.value;
+	else
+		speed = 1;
+	aspeed = speed * host_frametime;
+
+	// loop through the axes
+	for (i = 0; i < QUAKEGENERIC_JOY_MAX_AXES; i++)
+	{
+		fAxisValue = axisValues[i];
+
+		switch (dwAxisMap[i])
+		{
+		case AxisForward:
+			if ((joy_advanced.value == 0.0) && (in_mlook.state & 1))
+			{
+				// user wants forward control to become look control
+				if (fabs(fAxisValue) > joy_pitchthreshold.value)
+				{
+					// if mouse invert is on, invert the joystick pitch value
+					// only absolute control support here (joy_advanced is false)
+					if (m_pitch.value < 0.0)
+					{
+						cl.viewangles[PITCH] -= (fAxisValue * joy_pitchsensitivity.value) * aspeed * cl_pitchspeed.value;
+					}
+					else
+					{
+						cl.viewangles[PITCH] += (fAxisValue * joy_pitchsensitivity.value) * aspeed * cl_pitchspeed.value;
+					}
+					V_StopPitchDrift();
+				}
+				else
+				{
+					// no pitch movement
+					// disable pitch return-to-center unless requested by user
+					// *** this code can be removed when the lookspring bug is fixed
+					// *** the bug always has the lookspring feature on
+					if(lookspring.value == 0.0)
+						V_StopPitchDrift();
+				}
+			}
+			else
+			{
+				// user wants forward control to be forward control
+				if (fabs(fAxisValue) > joy_forwardthreshold.value)
+				{
+					cmd->forwardmove += (fAxisValue * joy_forwardsensitivity.value) * speed * cl_forwardspeed.value;
+				}
+			}
+			break;
+
+		case AxisSide:
+			if (fabs(fAxisValue) > joy_sidethreshold.value)
+			{
+				cmd->sidemove += (fAxisValue * joy_sidesensitivity.value) * speed * cl_sidespeed.value;
+			}
+			break;
+
+		case AxisTurn:
+			if ((in_strafe.state & 1) || (lookstrafe.value && (in_mlook.state & 1)))
+			{
+				// user wants turn control to become side control
+				if (fabs(fAxisValue) > joy_sidethreshold.value)
+				{
+					cmd->sidemove -= (fAxisValue * joy_sidesensitivity.value) * speed * cl_sidespeed.value;
+				}
+			}
+			else
+			{
+				// user wants turn control to be turn control
+				if (fabs(fAxisValue) > joy_yawthreshold.value)
+				{
+					if(dwControlMap[i] == JOY_ABSOLUTE_AXIS)
+					{
+						cl.viewangles[YAW] += (fAxisValue * joy_yawsensitivity.value) * aspeed * cl_yawspeed.value;
+					}
+					else
+					{
+						cl.viewangles[YAW] += (fAxisValue * joy_yawsensitivity.value) * speed * 180.0;
+					}
+
+				}
+			}
+			break;
+
+		case AxisLook:
+			if (in_mlook.state & 1)
+			{
+				if (fabs(fAxisValue) > joy_pitchthreshold.value)
+				{
+					// pitch movement detected and pitch movement desired by user
+					if(dwControlMap[i] == JOY_ABSOLUTE_AXIS)
+					{
+						cl.viewangles[PITCH] += (fAxisValue * joy_pitchsensitivity.value) * aspeed * cl_pitchspeed.value;
+					}
+					else
+					{
+						cl.viewangles[PITCH] += (fAxisValue * joy_pitchsensitivity.value) * speed * 180.0;
+					}
+					V_StopPitchDrift();
+				}
+				else
+				{
+					// no pitch movement
+					// disable pitch return-to-center unless requested by user
+					// *** this code can be removed when the lookspring bug is fixed
+					// *** the bug always has the lookspring feature on
+					if(lookspring.value == 0.0)
+						V_StopPitchDrift();
+				}
+			}
+			break;
+
+		default:
+			break;
+		}
+	}
+
+	// bounds check pitch
+	if (cl.viewangles[PITCH] > 80.0)
+		cl.viewangles[PITCH] = 80.0;
+	if (cl.viewangles[PITCH] < -70.0)
+		cl.viewangles[PITCH] = -70.0;
+
+}
+
 void IN_Move (usercmd_t *cmd)
 {
 	IN_MouseMove (cmd);
-	// TODO: Joystick input
+	IN_JoyMove (cmd);
 }
 

--- a/source/quakegeneric.h
+++ b/source/quakegeneric.h
@@ -26,6 +26,15 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define QUAKEGENERIC_RES_X 320
 #define QUAKEGENERIC_RES_Y 200
 
+#define QUAKEGENERIC_JOY_MAX_AXES 6
+#define QUAKEGENERIC_JOY_AXIS_X 0
+#define QUAKEGENERIC_JOY_AXIS_Y 1
+#define QUAKEGENERIC_JOY_AXIS_Z 2
+#define QUAKEGENERIC_JOY_AXIS_R 3
+#define QUAKEGENERIC_JOY_AXIS_U 4
+#define QUAKEGENERIC_JOY_AXIS_V 5
+
+
 // provided functions
 void QG_Tick(double duration);
 void QG_Create(int argc, char *argv[]);
@@ -37,5 +46,6 @@ void QG_DrawFrame(void *pixels);
 void QG_SetPalette(unsigned char palette[768]);
 int QG_GetKey(int *down, int *key);
 void QG_GetMouseMove(int *x, int *y);
+void QG_GetJoyAxes(float *axes);
 
 #endif // __QUAKEGENERIC__

--- a/source/quakegeneric_sdl2.c
+++ b/source/quakegeneric_sdl2.c
@@ -378,6 +378,12 @@ int main(int argc, char *argv[])
 						joy_axes[event.jaxis.axis] = event.jaxis.value / 32767.0f;
 					}
 					break;
+
+				case SDL_JOYBUTTONDOWN:
+				case SDL_JOYBUTTONUP:
+					button = event.jbutton.button + ((event.jbutton.button < 4) ? K_JOY1 : K_AUX1);
+					(void) KeyPush((event.type == SDL_JOYBUTTONDOWN), button);
+					break;
 			}
 		}
 


### PR DESCRIPTION
The joystick logic is mostly copied from `in_win.c` since it is much more powerful than `in_dos.c`.    These settings work pretty well for me on Linux with an Xbox one controller:

```
+mlook
joystick 1
joyadvanced 1
joyadvaxisx 3
joyadvaxisy 1
joyadvaxisr 4
joyadvaxisu 2
joysidesensitivity 1
bind joy1 +attack
bind joy2 +jump
joyadvancedupdate
```

The controller has to be available when the game starts.