### PR TITLE
increase surfcache size

### DIFF
--- a/source/vid_null.c
+++ b/source/vid_null.c
@@ -31,7 +31,7 @@ viddef_t	vid;				// global video state
 
 byte	vid_buffer[BASEWIDTH*BASEHEIGHT];
 short	zbuffer[BASEWIDTH*BASEHEIGHT];
-byte	surfcache[256*1024];
+byte	surfcache[SURFCACHE_SIZE_AT_320X200];
 
 unsigned short	d_8to16table[256];
 unsigned	d_8to24table[256];


### PR DESCRIPTION
![image](https://github.com/erysdren/quakegeneric/assets/1709642/482193db-e7d3-494e-9f75-c310373b540c)

In certain spots like this you get the cache thrash RAM icon appearing and under performance (or at least you do if your computer is slow enough to notice the difference).

This is because the surface cache in vid_null is too small to play all of id1 without occasionally filling the surface cache in a single frame.  Instead use the recommended setting for 320x200.