### PR TITLE
Improve Portability

### DIFF
--- a/source/console.c
+++ b/source/console.c
@@ -19,15 +19,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 // console.c
 
-#ifdef NeXT
-#include <libc.h>
-#endif
-#ifdef _MSC_VER
-#include <io.h> // open, write, close
-#else
-#include <unistd.h>
-#endif
-#include <fcntl.h>
+#include <stdio.h>
 #include "quakedef.h"
 
 int 		con_linewidth;
@@ -224,7 +216,7 @@ void Con_Init (void)
 		if (strlen (com_gamedir) < (MAXGAMEDIRLEN - strlen (t2)))
 		{
 			sprintf (temp, "%s%s", com_gamedir, t2);
-			unlink (temp);
+			remove (temp);
 		}
 	}
 
@@ -356,14 +348,14 @@ void Con_DebugLog(char *file, char *fmt, ...)
 {
     va_list argptr; 
     static char data[1024];
-    int fd;
+    FILE *fd;
     
     va_start(argptr, fmt);
     vsprintf(data, fmt, argptr);
     va_end(argptr);
-    fd = open(file, O_WRONLY | O_CREAT | O_APPEND, 0666);
-    write(fd, data, strlen(data));
-    close(fd);
+    fd = fopen(file, "wa");
+    fwrite(data, strlen(data), 1, fd);
+    fclose(fd);
 }
 
 

--- a/source/quakegeneric.h
+++ b/source/quakegeneric.h
@@ -35,6 +35,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define QUAKEGENERIC_JOY_AXIS_V 5
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // provided functions
 void QG_Tick(double duration);
 void QG_Create(int argc, char *argv[]);
@@ -47,5 +51,9 @@ void QG_SetPalette(unsigned char palette[768]);
 int QG_GetKey(int *down, int *key);
 void QG_GetMouseMove(int *x, int *y);
 void QG_GetJoyAxes(float *axes);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // __QUAKEGENERIC__

--- a/source/quakegeneric_null.c
+++ b/source/quakegeneric_null.c
@@ -30,6 +30,16 @@ int QG_GetKey(int *down, int *key)
 	return 0;
 }
 
+void QG_GetMouseMove(int *x, int *y)
+{
+
+}
+
+void QG_GetJoyAxes(float *axes)
+{
+    *axes = 0;
+}
+
 void QG_Quit(void)
 {
 


### PR DESCRIPTION
When porting quakegeneric to our C++ based teaching operating system [hhuOS](https://github.com/hhuOS/hhuOS), I noticed some minor issues, that I solved in this PR:

1. `quakegeneric.h`: Wrapping the functions in an `extern "C"` block, when `__cplusplus` is defined, allows quakegeneric to be compiled as part of a C++ application.
2. `quakegeneric_null.c`: `QG_GetMouseMove()` and `QG_GetJoxAxes()` were missing.
3. `console.c`: There are few calls to functions in `unistd.h` here, that can be replaced with equivalent functions from `stdio.h`. Since `hhuOS` does not have a POSIX interface, this was mandatory for us. Other (hobby) operating system might also benefit from this change.